### PR TITLE
last att

### DIFF
--- a/robot/analics.py
+++ b/robot/analics.py
@@ -1,0 +1,21 @@
+from app.models.tema import Tema
+from app.core.database import SessionLocal
+import joblib
+import os
+from app.ml.modelo import Modelo
+
+
+def carregar_modelos_dinamicamente(num_camadas=2, num_neuronios=10):
+    db = SessionLocal()
+    temas = db.query(Tema).filter(Tema.modelo_path != None).all()
+    db.close()
+
+    modelos = {}
+
+    for tema in temas:
+        modelo = Modelo(num_camadas, num_neuronios)
+        if os.path.exists(tema.modelo_path):
+            modelo.modelo = joblib.load(tema.modelo_path)
+            modelos[tema.nome.lower()] = modelo
+
+    return modelos

--- a/robot/app/api/routes.py
+++ b/robot/app/api/routes.py
@@ -1,18 +1,19 @@
 from fastapi import APIRouter
-from app.controllers.chatbot_controller import process_question, treinar_classificador_controller
+from app.controllers.chatbot_controller import process_question_controller, train_main_model_controller, train_specialized_models_controller
+
+router = APIRouter(prefix="/chatbot")
 
 
-router = APIRouter(prefix="/chatbot", tags=["Chatbot"])
+@router.post("/question")
+async def process_question_route(payload: dict):
+    return await process_question_controller(payload)
 
 
-@router.post("/ask")
-async def ask_question(payload: dict):
-    """
-    Endpoint to process a question and return the answer.
-    """
-    return await process_question(payload)
+@router.post("/train")
+async def train_main_model_route():
+    return await train_main_model_controller()
 
 
-@router.post("/treiner")
-async def train_model():
-    return await treinar_classificador_controller()
+@router.post("/train-specialized")
+async def train_specialized_models_route():
+    return await train_specialized_models_controller()

--- a/robot/app/controllers/chatbot_controller.py
+++ b/robot/app/controllers/chatbot_controller.py
@@ -3,6 +3,12 @@ from app.ml.training import treinar_classificador
 from app.ml.model_handler import salvar_modelo
 from app.ml.classifier import EmbeddingClassifier
 from app.repositories.question_repository import obter_dados_para_treinamento
+from app.repositories.question_repository import obter_dados_por_tema
+from app.models.tema import Tema
+from app.core.database import SessionLocal
+from app.ml.model_handler import Modelo
+import joblib
+import os
 
 
 async def process_question(payload: dict):
@@ -29,3 +35,26 @@ async def treinar_classificador_controller():
         return {"status": "Modelo treinado e salvo com sucesso."}
     except Exception as e:
         return {"error": str(e)}
+
+
+async def treinar_modelos_especializados_controller():
+    db = SessionLocal()
+    temas = db.query(Tema).all()
+    db.close()
+
+    for tema in temas:
+        embedding, labels = obter_dados_por_tema(tema.id)
+
+        if not embedding:
+            print(f"Sem dados para tema: {tema.nome}")
+            continue
+
+        modelo = Modelo(num_camadas=2, num_neuronios=10)
+        modelo.treinar(embedding, labels)
+
+        os.makedirs("models", exist_ok=True)
+        caminho = f"models/{tema.nome.lower()}_model.sav"
+        joblib.dump(modelo.modelo, caminho)
+        print(f"Modelo treinado e salvo para o tema: {tema.nome} em {caminho}")
+
+    return {"status": "Modelos especializados treinados e salvos com sucesso."}

--- a/robot/app/ml/orchestrator.py
+++ b/robot/app/ml/orchestrator.py
@@ -1,0 +1,16 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class Orchestrator(nn.Module):
+    def __init__(self, input_size=384, hidden_size=128, num_outputs=3):
+        # num_outputs: representa as ações que o orquestrador pode tomar
+        super(Orchestrator, self).__init__()
+        self.fc1 = nn.Linear(input_size, hidden_size)
+        self.fc2 = nn.Linear(hidden_size, num_outputs)
+        # Ex: [usar_modelo, criar_modelo, usar_opanai]
+
+    def forward(self, x):
+        x = F.relu(self.fc1(x))
+        return self.fc2(x)

--- a/robot/app/ml/orchestrator_handler.py
+++ b/robot/app/ml/orchestrator_handler.py
@@ -1,0 +1,24 @@
+import torch
+import os
+from app.ml.orchestrator import Orchestrator
+
+ORCHESTRATOR_MODEL_PATH = "models/orchestrator_model.pth"
+
+
+def save_orchestrator(model, path=ORCHESTRATOR_MODEL_PATH):
+    """
+    Save the orchestrator model to a file.
+    """
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    torch.save(model.state_dict(), path)
+
+
+def load_orchestrator(input_size=384, num_outputs=3, path=ORCHESTRATOR_MODEL_PATH):
+    """
+    Load the orchestrator model from a file.
+    """
+    model = Orchestrator(input_size, 128, num_outputs)
+    model.load_state_dict(torch.load(path))
+    model.eval()
+
+    return model

--- a/robot/app/ml/orchestrator_training.py
+++ b/robot/app/ml/orchestrator_training.py
@@ -1,0 +1,26 @@
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+from app.ml.orchestrator import Orchestrator
+
+
+def train_orchestrator(X, y, epochs=20, batch_size=16, lr=0.001):
+    inputs = torch.tensor(X, dtype=torch.float32)
+    targets = torch.tensor(y, dtype=torch.long)
+
+    dataset = TensorDataset(inputs, targets)
+    loader = DataLoader(dataset, batch_size=batch_size, shuffle=True)
+
+    model = Orchestrator(input_size=inputs.shape[1], num_outputs=len(set(y)))
+    criterion = torch.nn.CrossEntropyLoss()
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+
+    model.train()
+    for epoch in range(epochs):
+        for batch_X, batch_y in loader:
+            optimizer.zero_grad()
+            outputs = model(batch_X)
+            loss = criterion(outputs, batch_y)
+            loss.backward()
+            optimizer.step()
+
+    return model

--- a/robot/app/repositories/question_repository.py
+++ b/robot/app/repositories/question_repository.py
@@ -61,3 +61,22 @@ def get_training_data():
 
     num_class = len(set(labels))
     return embeddings, labels, num_class
+
+
+def get_data_by_theme(theme_id: int):
+    db: Session = SessionLocal()
+    registros = db.query(Question).filter(
+        Question.temaId == theme_id,
+        Question.embedding.isnot(None)
+    ).all()
+    db.close()
+
+    embeddings = []
+    labels = []
+
+    for r in registros:
+        emb = np.frombuffer(r.embedding, dtype=np.float32)
+        embeddings.append(emb)
+        labels.append(0)  # sempre 0 pois é um modelo binário por tema
+
+    return embeddings, labels

--- a/robot/app/services/openai_services.py
+++ b/robot/app/services/openai_services.py
@@ -36,4 +36,4 @@ def obter_resposta_openai(question: str) -> str:
         return response.choices[0].message['content'].strip()
     except Exception as e:
         print(f"Erro ao obter resposta da OpenAI: {str(e)}")
-        return "Desculpe, não consegui processar sua pergunta no momento."
+        return "Desculpe, não consigo processar sua pergunta no momento."

--- a/robot/app/use_cases/process_question.py
+++ b/robot/app/use_cases/process_question.py
@@ -1,44 +1,64 @@
-from app.services.embedding_services import gerar_embedding
-from app.services.openai_services import obter_resposta_openai
-from app.repositories.question_repository import buscar_resposta_similar, salvar_pergunta_resposta
-from app.ml.model_handler import carregar_modelo
-from app.ml.classifier import EmbeddingClassifier
+from app.services.embedding_services import generate_embedding
+from app.services.openai_services import get_openai_response
+from app.repositories.question_repository import find_similar_response, save_question_response
+from app.ml.orchestrator_handler import load_orchestrator
+from app.ml.dispatcher import execute_specialized_model
 import torch
 
-# Parametros do modelo
-INPUT_SIZE = 384
-NUM_CLASSES = 5
+# Carrega o modelo orquestrador treinado
+orchestrator_model = load_orchestrator()
 
-# Carregar o modelo treinado
-modelo_classificador = carregar_modelo(EmbeddingClassifier, INPUT_SIZE, NUM_CLASSES)
+# Definições de ação
+ACTION_USE_SPECIALIZED = 0
+ACTION_CREATE_MODEL = 1
+ACTION_USE_OPENAI = 2
 
-mapa_tema_id = {
+# Mapeamento fixo de tema para modelo
+theme_to_model = {
     0: "sap",
-    1: "vendas",
+    1: "vendas"
 }
 
 
-async def handle_question(question: str, systemId: int, sisId: int):
-    # 1. Gera embedding
-    embedding = gerar_embedding(question)
+async def handle_question(question: str, system_id: int, user_id: int):
+    # 1. Gera o embedding da pergunta
+    embedding = generate_embedding(question)
 
-    # 2. Previsão de tema com rede neural
-    entrada = torch.tensor([embedding], dtype=torch.float32)
-    saida = modelo_classificador(entrada)
-    tema_previsto = torch.argmax(saida, dim=1).item()
+    # 2. Passa pela rede neural orquestradora
+    input_tensor = torch.tensor([embedding], dtype=torch.float32)
+    action_logits = orchestrator_model(input_tensor)
+    action = torch.argmax(action_logits, dim=1).item()
 
-    # (Opcional) imprimir ou logar o tema previsto
-    print(f"Tema previsto: {tema_previsto}")
+    print(f"[ORCHESTRATOR] Ação sugerida: {action}")
 
-    # 3. Busca por resposta similar (por embedding e sistema)
-    resposta_existente = buscar_resposta_similar(embedding, systemId)
-    if resposta_existente:
-        return resposta_existente
+    # 3. Executa ação com base no output da rede
+    if action == ACTION_USE_SPECIALIZED:
+        # Previsão de tema e execução do modelo especializado
+        theme_id = torch.argmax(action_logits, dim=1).item()
+        area = theme_to_model.get(theme_id)
+        if area:
+            result = execute_specialized_model(area, embedding)
+            print(f"[SPECIALIZED MODEL] Resultado: {result}")
 
-    # 4. Fallback: OpenAI
-    resposta = obter_resposta_openai(question)
+    elif action == ACTION_CREATE_MODEL:
+        # Aqui apenas loga por enquanto
+        print("[AUTOEXPANSION] Novo modelo sugerido para criação futura.")
 
-    # 5. Armazena para aprendizado futuro
-    salvar_pergunta_resposta(question, resposta, embedding, systemId, sisId)
+    # 4. Tenta buscar resposta similar no banco
+    similar_response = find_similar_response(embedding, system_id)
+    if similar_response:
+        return similar_response
 
-    return resposta
+    # 5. Fallback: OpenAI
+    openai_response = await get_openai_response(question)
+
+    # 6. Salva pergunta e resposta
+    save_question_response(
+        question=question,
+        response=openai_response,
+        embedding=embedding,
+        system_id=system_id,
+        user_id=user_id
+    )
+
+    return openai_response


### PR DESCRIPTION
## Resumo por Sourcery

Introduz um modelo de orquestrador para decidir como processar as perguntas recebidas, substituindo o modelo de classificação único anterior. Isso permite rotear as perguntas para modelos especializados com base em temas ou recorrer a um provedor geral. Adiciona funcionalidade para treinar esses modelos especializados.

Novas Funcionalidades:
- Implementa uma rede neural de orquestrador para escolher entre usar um modelo especializado, registrar uma solicitação para um novo modelo ou usar o OpenAI.
- Adiciona a capacidade de treinar modelos especializados para diferentes temas por meio de um novo endpoint de API.
- Implementa a lógica de treinamento para o modelo de orquestrador.
- Adiciona funcionalidade para carregar dinamicamente modelos especializados treinados com base em dados de tema.
- Adiciona função de repositório para buscar dados de treinamento filtrados por tema.
- Expõe o treinamento de modelo especializado por meio de um novo endpoint de API `/chatbot/train-specialized`.
- Expõe o treinamento do modelo principal por meio do endpoint de API renomeado `/chatbot/train`.
- Renomeia o endpoint de processamento de perguntas de `/ask` para `/question`.
- Adiciona funções de manipulador para salvar e carregar o modelo de orquestrador.
- Adiciona script de treinamento para o modelo de orquestrador.
- Adiciona módulo para carregar dinamicamente modelos especializados (`analics.py`).

Melhorias:
- Refatora o caso de uso de processamento de perguntas (`process_question.py`) para usar a decisão do modelo de orquestrador.
- Renomeia várias funções, variáveis, parâmetros e endpoints de API de português para inglês para consistência e clareza (por exemplo, `gerar_embedding` -> `generate_embedding`, `treinar_classificador_controller` -> `train_main_model_controller`).

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an orchestrator model to decide how to process incoming questions, replacing the previous single classification model. This allows routing questions to specialized models based on themes or falling back to a general provider. Add functionality to train these specialized models.

New Features:
- Implement an orchestrator neural network to choose between using a specialized model, logging a request for a new model, or using OpenAI.
- Add the capability to train specialized models for different themes via a new API endpoint.
- Implement training logic for the orchestrator model.
- Add functionality to dynamically load trained specialized models based on theme data.
- Add repository function to fetch training data filtered by theme.
- Expose specialized model training through a new API endpoint `/chatbot/train-specialized`.
- Expose main model training through the renamed API endpoint `/chatbot/train`.
- Rename question processing endpoint from `/ask` to `/question`.
- Add handler functions to save and load the orchestrator model.
- Add training script for the orchestrator model.
- Add module for dynamically loading specialized models (`analics.py`).

Enhancements:
- Refactor the question processing use case (`process_question.py`) to use the orchestrator model's decision.
- Rename various functions, variables, parameters, and API endpoints from Portuguese to English for consistency and clarity (e.g., `gerar_embedding` -> `generate_embedding`, `treinar_classificador_controller` -> `train_main_model_controller`).

</details>